### PR TITLE
Add local webpage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # toposim
 topology simulator
+
+## Running the webpage locally
+
+If you have built the project website or documentation as static HTML files,
+you can preview it locally with Python's built-in HTTP server:
+
+1. Open a terminal and change into the directory that contains your `index.html`.
+2. Run `python -m http.server 8000`.
+3. Navigate to `http://localhost:8000` in your web browser to view the page.
+
+This approach works on any system that has Python installed and requires no
+additional dependencies.


### PR DESCRIPTION
## Summary
- provide steps for running a local static web server in the README

## Testing
- `pytest -q` *(fails: command not found)*